### PR TITLE
feat: allow conditionally setting eager load

### DIFF
--- a/src/Core/Schema/Concerns/EagerLoadable.php
+++ b/src/Core/Schema/Concerns/EagerLoadable.php
@@ -19,22 +19,38 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Core\Schema\Concerns;
 
+use Closure;
+use InvalidArgumentException;
+
 trait EagerLoadable
 {
 
     /**
-     * @var bool
+     * @var Closure|bool
      */
     private bool $includePath = true;
+
+    /**
+     * @param Closure|bool $callback
+     * @return $this
+     */
+    public function canEagerLoad($callback = true): self
+    {
+        if (!is_bool($callback) && !$callback instanceof Closure) {
+            throw new InvalidArgumentException('Expecting a boolean or closure.');
+        }
+
+        $this->includePath = $callback;
+
+        return $this;
+    }
 
     /**
      * @return $this
      */
     public function cannotEagerLoad(): self
     {
-        $this->includePath = false;
-
-        return $this;
+        return $this->canEagerLoad(false);
     }
 
     /**
@@ -44,6 +60,10 @@ trait EagerLoadable
      */
     public function isIncludePath(): bool
     {
+        if ($this->includePath instanceof Closure) {
+            $this->includePath = ($this->includePath)();
+        }
+
         return $this->includePath;
     }
 }


### PR DESCRIPTION
I'd like to conditionally allow/disallow eager loading, just like you can conditionally hide/show a field. A simple boolean would be enough in my use case, but to make it more in line with `hidden` and `readOnly` I've also added closure support. The only difference is that these closures receive a request and the new one doesn't as I couldn't find a good way to get the request.

N.B. I had first added the parameter to the existing `cannotEagerLoad` method, but that was pretty confusing due to the double negation.

### Before
```php
/**
 * @return \LaravelJsonApi\Contracts\Schema\Field[]
 */
public function fields(): array
{
    $userField = BelongsTo::make('user');
    if (Gate::denies('viewUser', Blog::class)) {
        $userField->cannotEagerLoad();
    }

    return [
        ID::make()->uuid(),
        $userField,
    ];
}
```

### After
```php
/**
 * @return \LaravelJsonApi\Contracts\Schema\Field[]
 */
public function fields(): array
{
    return [
        ID::make()->uuid(),
        BelongsTo::make('user')->canEagerLoad(Gate::allows('viewUser', Blog::class)),
    ];
}
```