### PR TITLE
Allow stdClass input values for ArrayHash properties

### DIFF
--- a/src/Core/Json/Hash.php
+++ b/src/Core/Json/Hash.php
@@ -47,6 +47,10 @@ class Hash implements ArrayAccess, Arrayable, Countable, IteratorAggregate, Json
             $value = $value->jsonSerialize();
         }
 
+        if ($value instanceof \stdClass) {
+            $value = (array) $value;
+        }
+
         if (is_array($value) || is_null($value)) {
             return new self($value);
         }


### PR DESCRIPTION
When model properties are cased to `object` and added as `ArrayHash` in JSON schema class, validation currently fails with an exception. This PR checks for stdClass objects which are the result of `(object) $value` casts and casts them back to an array.