### PR TITLE
Feat/matches ids ulid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 vendor/
 composer.lock
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 vendor/
 composer.lock
 .phpunit.result.cache

--- a/src/Core/Schema/Concerns/MatchesIds.php
+++ b/src/Core/Schema/Concerns/MatchesIds.php
@@ -59,7 +59,7 @@ trait MatchesIds
      */
     public function ulid(): self
     {
-        return $this->matchAs('[0-7][0-9A-HJKMNP-TV-Z]{25}');
+        return $this->matchAs('[0-7][0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{25}');
     }
 
     /**

--- a/src/Core/Schema/Concerns/MatchesIds.php
+++ b/src/Core/Schema/Concerns/MatchesIds.php
@@ -53,6 +53,16 @@ trait MatchesIds
     }
 
     /**
+     * Mark the ID field as a ULID.
+     *
+     * @return $this
+     */
+    public function ulid(): self
+    {
+        return $this->matchAs('[0-7][0-9A-HJKMNP-TV-Z]{25}');
+    }
+
+    /**
      * Set the pattern for the ID field.
      *
      * @param string $pattern


### PR DESCRIPTION
# Summary
Add possibility to match ULID route key.

## FYI
- [Laravel documentation](https://laravel.com/docs/10.x/routing#parameters-regular-expression-constraints)
- Use same regex than [`whereUlid`](https://github.com/laravel/framework/blob/53b02b3c1d926c095cccca06883a35a5c6729773/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php#L48) method when defining routes.
