### PR TITLE
Feature: upgrade to Laravel 11 and drop support for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
-        laravel: [10]
+        php: [8.2, 8.3]
+        laravel: [11]
 
     steps:
     - name: Checkout Code

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 vendor/
 composer.lock
-.phpunit.result.cache
+.phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
-## Unreleased
+## Unreleased (Laravel 11)
+
+### Changed
+
+- **BREAKING** Package now requires Laravel 11.
+- Minimum PHP version is now `8.2`.
 
 ## [3.3.0] - 2023-11-08
 

--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,10 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "3.x-dev",
-            "dev-laravel11": "4.x-dev"
+            "dev-develop": "4.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/support": "^11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.28"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "illuminate/contracts": "^10.0",
-        "illuminate/http": "^10.0",
-        "illuminate/support": "^10.0"
+        "illuminate/contracts": "^11.0",
+        "illuminate/http": "^11.0",
+        "illuminate/support": "^11.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.28"
@@ -45,10 +45,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "3.x-dev"
+            "dev-develop": "3.x-dev",
+            "dev-laravel11": "4.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         verbose="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit/</directory>
-        </testsuite>
-        <testsuite name="Integration">
-            <directory suffix="Test.php">./tests/Integration/</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <ini name="error_reporting" value="E_ALL"/>
-    </php>
+  <coverage/>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit/</directory>
+    </testsuite>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">./tests/Integration/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="error_reporting" value="E_ALL"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/Unit/Document/ResourceIdentifierTest.php
+++ b/tests/Unit/Document/ResourceIdentifierTest.php
@@ -44,7 +44,7 @@ class ResourceIdentifierTest extends TestCase
     /**
      * @return array
      */
-    public function emptyIdProvider(): array
+    public static function emptyIdProvider(): array
     {
         return [
             [''],

--- a/tests/Unit/Document/ResourceObjectTest.php
+++ b/tests/Unit/Document/ResourceObjectTest.php
@@ -256,7 +256,7 @@ class ResourceObjectTest extends TestCase
     /**
      * @return array
      */
-    public function pointerProvider(): array
+    public static function pointerProvider(): array
     {
         return [
             ['type', '/type'],
@@ -298,7 +298,7 @@ class ResourceObjectTest extends TestCase
     /**
      * @return array
      */
-    public function pointerForRelationshipProvider(): array
+    public static function pointerForRelationshipProvider(): array
     {
         return [
             ['author', null],

--- a/tests/Unit/Exceptions/JsonApiExceptionTest.php
+++ b/tests/Unit/Exceptions/JsonApiExceptionTest.php
@@ -91,7 +91,7 @@ class JsonApiExceptionTest extends TestCase
     /**
      * @return array[]
      */
-    public function is4xxProvider(): array
+    public static function is4xxProvider(): array
     {
         return [
             [100, false],
@@ -122,7 +122,7 @@ class JsonApiExceptionTest extends TestCase
     /**
      * @return array[]
      */
-    public function is5xxProvider(): array
+    public static function is5xxProvider(): array
     {
         return [
             [100, false],

--- a/tests/Unit/Query/QueryParametersTest.php
+++ b/tests/Unit/Query/QueryParametersTest.php
@@ -35,7 +35,7 @@ class QueryParametersTest extends TestCase
     /**
      * @return array
      */
-    public function keyProvider(): array
+    public static function keyProvider(): array
     {
         return [
             'fields' => ['fields', 'sparseFieldSets'],

--- a/tests/Unit/Schema/IncludePathIteratorTest.php
+++ b/tests/Unit/Schema/IncludePathIteratorTest.php
@@ -81,7 +81,7 @@ class IncludePathIteratorTest extends TestCase
     /**
      * @return array[]
      */
-    public function depthProvider(): array
+    public static function depthProvider(): array
     {
         return [
             'one' => [1, ['author', 'comments', 'image']],
@@ -160,7 +160,7 @@ class IncludePathIteratorTest extends TestCase
     /**
      * @return array[]
      */
-    public function polymorphProvider(): array
+    public static function polymorphProvider(): array
     {
         return [
             'one' => [1, ['imageable']],

--- a/tests/Unit/Store/LazyRelationTest.php
+++ b/tests/Unit/Store/LazyRelationTest.php
@@ -64,7 +64,7 @@ class LazyRelationTest extends TestCase
     /**
      * @return array
      */
-    public function validToOneProvider(): array
+    public static function validToOneProvider(): array
     {
         return [
             'user' => [
@@ -138,7 +138,7 @@ class LazyRelationTest extends TestCase
     /**
      * @return array
      */
-    public function invalidIdentifierProvider(): array
+    public static function invalidIdentifierProvider(): array
     {
         return [
             'no type' => [

--- a/tests/Unit/Support/ArrTest.php
+++ b/tests/Unit/Support/ArrTest.php
@@ -105,7 +105,7 @@ class ArrTest extends TestCase
     /**
      * @return array
      */
-    public function methodsProvider(): array
+    public static function methodsProvider(): array
     {
         return [
             ['camelize'],

--- a/tests/Unit/Support/StrTest.php
+++ b/tests/Unit/Support/StrTest.php
@@ -26,7 +26,7 @@ class StrTest extends TestCase
     /**
      * @return array
      */
-    public function dasherizeProvider(): array
+    public static function dasherizeProvider(): array
     {
         return [
             'simple' => ['foo', 'foo'],
@@ -49,7 +49,7 @@ class StrTest extends TestCase
     /**
      * @return array
      */
-    public function snakeProvider(): array
+    public static function snakeProvider(): array
     {
         return [
             'simple' => ['foo', 'foo'],
@@ -72,7 +72,7 @@ class StrTest extends TestCase
     /**
      * @return array
      */
-    public function underscoreProvider(): array
+    public static function underscoreProvider(): array
     {
         return [
             ['foo', 'foo'],
@@ -97,7 +97,7 @@ class StrTest extends TestCase
     /**
      * @return array
      */
-    public function camelizeProvider(): array
+    public static function camelizeProvider(): array
     {
         return [
             ['foo', 'foo'],


### PR DESCRIPTION
PR for code changes required to support Laravel 11.

Laravel 11 drops support for PHP 8.1, so we can do the same here.