### PR TITLE
fix: related relationship responses top level links `self` link should be the relations `related` link

### DIFF
--- a/src/Core/Document/Links.php
+++ b/src/Core/Document/Links.php
@@ -191,6 +191,14 @@ class Links implements Serializable, IteratorAggregate, Countable, ArrayAccess
         return $this->has('related');
     }
 
+    public function relatedAsSelf(): self
+    {
+        if($this->forget('self')->hasRelated()){
+            $this->push(Link::fromArray('self', $this->getRelated()->toArray()));
+        }
+        return $this->forget('related');
+    }
+
     /**
      * Push links into the collection.
      *

--- a/src/Core/Responses/Internal/RelatedResourceCollectionResponse.php
+++ b/src/Core/Responses/Internal/RelatedResourceCollectionResponse.php
@@ -14,6 +14,7 @@ namespace LaravelJsonApi\Core\Responses\Internal;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use LaravelJsonApi\Core\Document\Links;
 use LaravelJsonApi\Core\Resources\JsonApiResource;
 use LaravelJsonApi\Core\Responses\Concerns\HasEncodingParameters;
 use LaravelJsonApi\Core\Responses\Concerns\HasRelationship;
@@ -59,7 +60,7 @@ class RelatedResourceCollectionResponse implements Responsable
             ->withResources($this->related)
             ->withJsonApi($this->jsonApi())
             ->withMeta($this->allMeta())
-            ->withLinks($this->allLinks())
+            ->withLinks($this->allLinks()->relatedAsSelf())
             ->toJson($this->encodeOptions);
 
         return new Response(

--- a/src/Core/Responses/Internal/RelatedResourceResponse.php
+++ b/src/Core/Responses/Internal/RelatedResourceResponse.php
@@ -14,6 +14,7 @@ namespace LaravelJsonApi\Core\Responses\Internal;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use LaravelJsonApi\Core\Document\Links;
 use LaravelJsonApi\Core\Resources\JsonApiResource;
 use LaravelJsonApi\Core\Responses\Concerns\HasEncodingParameters;
 use LaravelJsonApi\Core\Responses\Concerns\HasRelationship;
@@ -52,6 +53,7 @@ class RelatedResourceResponse implements Responsable
     {
         $encoder = $this->server()->encoder();
 
+        $links = $this->allLinks();
         $document = $encoder
             ->withRequest($request)
             ->withIncludePaths($this->includePaths($request))
@@ -59,7 +61,7 @@ class RelatedResourceResponse implements Responsable
             ->withResource($this->related)
             ->withJsonApi($this->jsonApi())
             ->withMeta($this->allMeta())
-            ->withLinks($this->allLinks())
+            ->withLinks($this->allLinks()->relatedAsSelf())
             ->toJson($this->encodeOptions);
 
         return new Response(

--- a/tests/Unit/Document/LinksTest.php
+++ b/tests/Unit/Document/LinksTest.php
@@ -294,4 +294,23 @@ JSON;
 
         $this->assertSame(['related' => $related], $links->all());
     }
+
+    public function testRelatedToSelfWithRelated(): void
+    {
+        $links = new Links(
+            new Link('self', '/api/posts/1/relationships/author'),
+            new Link('related', '/api/posts/1/author'),
+        );
+
+        $this->assertEquals(['self' => new Link('self', '/api/posts/1/author'),], $links->relatedAsSelf()->all());
+    }
+
+    public function testRelatedToSelfWithoutRelated(): void
+    {
+        $links = new Links(
+            new Link('self', '/api/posts/1/relationships/author'),
+        );
+
+        $this->assertTrue($links->relatedAsSelf()->isEmpty());
+    }
 }


### PR DESCRIPTION
[The spec](https://jsonapi.org/format/1.0/#document-top-level) states top level links objects may contain a `self` link as `the link that generated the current response document.`

Currently relationship `related` endpoints will return a `self` link that points to the `relationship` endpoint.

This PR corrects this so that the self link is replaced with the value of the `related` link and the redundant `related` link removed on related responses.

This is the cleanest way I could see to implement it but happy to rework it if needed.