### PR TITLE
Bugfix: withHeaders should merge headers rather than replace

### DIFF
--- a/src/Core/Responses/Concerns/IsResponsable.php
+++ b/src/Core/Responses/Concerns/IsResponsable.php
@@ -154,11 +154,12 @@ trait IsResponsable
      * Set response headers.
      *
      * @param array $headers
+     * @param bool $merge
      * @return $this
      */
     public function withHeaders(array $headers): self
     {
-        $this->headers = $headers;
+        $this->headers = array_merge($this->headers, $headers);
 
         return $this;
     }


### PR DESCRIPTION
It is currently impossible to set custom headers on a Resource class response without a custom controller since the specific response object's headers are replaced by the wrapping DataResponse object.

This PR changes the behaviour of witHeaders to merge rather than replace.

BREAKING CHANGE: direct use of withHeaders will now merge rather than replace this may lead to unexpected results