### PR TITLE
feat: support Illuminate\Auth\Access\Response returns from gates/policies in Authorizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
+        "illuminate/auth": "^11.33",
         "illuminate/contracts": "^11.0",
         "illuminate/http": "^11.0",
         "illuminate/support": "^11.0"

--- a/src/Contracts/Auth/Authorizer.php
+++ b/src/Contracts/Auth/Authorizer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Contracts\Auth;
 
+use Illuminate\Auth\Access\Response;
 use Illuminate\Http\Request;
 
 interface Authorizer
@@ -20,45 +21,45 @@ interface Authorizer
      *
      * @param Request $request
      * @param string $modelClass
-     * @return bool
+     * @return bool|Response
      */
-    public function index(Request $request, string $modelClass): bool;
+    public function index(Request $request, string $modelClass): bool|Response;
 
     /**
      * Authorize the store controller action.
      *
      * @param Request $request
      * @param string $modelClass
-     * @return bool
+     * @return bool|Response
      */
-    public function store(Request $request, string $modelClass): bool;
+    public function store(Request $request, string $modelClass): bool|Response;
 
     /**
      * Authorize the show controller action.
      *
      * @param Request $request
      * @param object $model
-     * @return bool
+     * @return bool|Response
      */
-    public function show(Request $request, object $model): bool;
+    public function show(Request $request, object $model): bool|Response;
 
     /**
      * Authorize the update controller action.
      *
      * @param object $model
      * @param Request $request
-     * @return bool
+     * @return bool|Response
      */
-    public function update(Request $request, object $model): bool;
+    public function update(Request $request, object $model): bool|Response;
 
     /**
      * Authorize the destroy controller action.
      *
      * @param Request $request
      * @param object $model
-     * @return bool
+     * @return bool|Response
      */
-    public function destroy(Request $request, object $model): bool;
+    public function destroy(Request $request, object $model): bool|Response;
 
     /**
      * Authorize the show-related controller action.
@@ -66,9 +67,9 @@ interface Authorizer
      * @param Request $request
      * @param object $model
      * @param string $fieldName
-     * @return bool
+     * @return bool|Response
      */
-    public function showRelated(Request $request, object $model, string $fieldName): bool;
+    public function showRelated(Request $request, object $model, string $fieldName): bool|Response;
 
     /**
      * Authorize the show-relationship controller action.
@@ -76,9 +77,9 @@ interface Authorizer
      * @param Request $request
      * @param object $model
      * @param string $fieldName
-     * @return bool
+     * @return bool|Response
      */
-    public function showRelationship(Request $request, object $model, string $fieldName): bool;
+    public function showRelationship(Request $request, object $model, string $fieldName): bool|Response;
 
     /**
      * Authorize the update-relationship controller action.
@@ -86,9 +87,9 @@ interface Authorizer
      * @param Request $request
      * @param object $model
      * @param string $fieldName
-     * @return bool
+     * @return bool|Response
      */
-    public function updateRelationship(Request $request, object $model, string $fieldName): bool;
+    public function updateRelationship(Request $request, object $model, string $fieldName): bool|Response;
 
     /**
      * Authorize the attach-relationship controller action.
@@ -96,9 +97,9 @@ interface Authorizer
      * @param Request $request
      * @param object $model
      * @param string $fieldName
-     * @return bool
+     * @return bool|Response
      */
-    public function attachRelationship(Request $request, object $model, string $fieldName): bool;
+    public function attachRelationship(Request $request, object $model, string $fieldName): bool|Response;
 
     /**
      * Authorize the detach-relationship controller action.
@@ -106,7 +107,7 @@ interface Authorizer
      * @param Request $request
      * @param object $model
      * @param string $fieldName
-     * @return bool
+     * @return bool|Response
      */
-    public function detachRelationship(Request $request, object $model, string $fieldName): bool;
+    public function detachRelationship(Request $request, object $model, string $fieldName): bool|Response;
 }

--- a/src/Core/Auth/Authorizer.php
+++ b/src/Core/Auth/Authorizer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace LaravelJsonApi\Core\Auth;
 
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Auth\Access\Response;
 use Illuminate\Http\Request;
 use LaravelJsonApi\Contracts\Auth\Authorizer as AuthorizerContract;
 use LaravelJsonApi\Contracts\Schema\Schema;
@@ -47,10 +48,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function index(Request $request, string $modelClass): bool
+    public function index(Request $request, string $modelClass): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'viewAny',
                 $modelClass
             );
@@ -62,10 +63,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function store(Request $request, string $modelClass): bool
+    public function store(Request $request, string $modelClass): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'create',
                 $modelClass
             );
@@ -77,10 +78,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function show(Request $request, object $model): bool
+    public function show(Request $request, object $model): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'view',
                 $model
             );
@@ -92,10 +93,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function update(Request $request, object $model): bool
+    public function update(Request $request, object $model): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'update',
                 $model
             );
@@ -107,10 +108,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function destroy(Request $request, object $model): bool
+    public function destroy(Request $request, object $model): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'delete',
                 $model
             );
@@ -122,10 +123,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function showRelated(Request $request, object $model, string $fieldName): bool
+    public function showRelated(Request $request, object $model, string $fieldName): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'view' . Str::classify($fieldName),
                 $model
             );
@@ -137,7 +138,7 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function showRelationship(Request $request, object $model, string $fieldName): bool
+    public function showRelationship(Request $request, object $model, string $fieldName): bool|Response
     {
         return $this->showRelated($request, $model, $fieldName);
     }
@@ -145,10 +146,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function updateRelationship(Request $request, object $model, string $fieldName): bool
+    public function updateRelationship(Request $request, object $model, string $fieldName): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'update' . Str::classify($fieldName),
                 [$model, $this->createRelation($request, $fieldName)]
             );
@@ -160,10 +161,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function attachRelationship(Request $request, object $model, string $fieldName): bool
+    public function attachRelationship(Request $request, object $model, string $fieldName): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'attach' . Str::classify($fieldName),
                 [$model, $this->createRelation($request, $fieldName)]
             );
@@ -175,10 +176,10 @@ class Authorizer implements AuthorizerContract
     /**
      * @inheritDoc
      */
-    public function detachRelationship(Request $request, object $model, string $fieldName): bool
+    public function detachRelationship(Request $request, object $model, string $fieldName): bool|Response
     {
         if ($this->mustAuthorize()) {
-            return $this->gate->check(
+            return $this->gate->inspect(
                 'detach' . Str::classify($fieldName),
                 [$model, $this->createRelation($request, $fieldName)]
             );


### PR DESCRIPTION
This adds support in the Authorizer for Illuminate\Auth\Access\Response returns from gates/polices.

This PR is a dependency of the necessary updates in the laravel repo here: https://github.com/laravel-json-api/laravel/pull/298