### PR TITLE
Make JSON:API server configurable using Attributes

### DIFF
--- a/src/Core/Attributes/ServeSchema.php
+++ b/src/Core/Attributes/ServeSchema.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Core\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class ServeSchema
+{
+    /**
+     * @param array|class-string $schema
+     */
+    public function __construct(
+        public array|string $schema,
+    ) {}
+}

--- a/src/Core/Server/Server.php
+++ b/src/Core/Server/Server.php
@@ -23,6 +23,7 @@ use LaravelJsonApi\Contracts\Resources\Container as ResourceContainerContract;
 use LaravelJsonApi\Contracts\Schema\Container as SchemaContainerContract;
 use LaravelJsonApi\Contracts\Server\Server as ServerContract;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
+use LaravelJsonApi\Core\Attributes\ServeSchema;
 use LaravelJsonApi\Core\Document\JsonApi;
 use LaravelJsonApi\Core\Resources\Container as ResourceContainer;
 use LaravelJsonApi\Core\Resources\Factory as ResourceFactory;
@@ -30,6 +31,8 @@ use LaravelJsonApi\Core\Schema\Container as SchemaContainer;
 use LaravelJsonApi\Core\Store\Store;
 use LaravelJsonApi\Core\Support\AppResolver;
 use LogicException;
+use ReflectionAttribute;
+use ReflectionClass;
 
 abstract class Server implements ServerContract
 {
@@ -65,7 +68,13 @@ abstract class Server implements ServerContract
      *
      * @return array
      */
-    abstract protected function allSchemas(): array;
+    protected function allSchemas(): array
+    {
+        return (new Collection((new ReflectionClass(static::class))->getAttributes(ServeSchema::class)))
+            ->map(fn (ReflectionAttribute $attribute): array => $attribute->getArguments())
+            ->flatten()
+            ->all();
+    }
 
     /**
      * Server constructor.

--- a/tests/Unit/Server/ServerWithAttributesTest.php
+++ b/tests/Unit/Server/ServerWithAttributesTest.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Core\Tests\Unit\Server;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Foundation\Application;
+use LaravelJsonApi\Core\Server\ServerRepository;
+use LaravelJsonApi\Core\Support\AppResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ServerWithAttributesTest extends TestCase
+{
+    /**
+     * @var MockObject&Application
+     */
+    private Application&MockObject $app;
+
+    /**
+     * @var MockObject&ConfigRepository
+     */
+    private ConfigRepository&MockObject $config;
+
+    /**
+     * @var AppResolver
+     */
+    private AppResolver $resolver;
+
+    /**
+     * @var ServerRepository
+     */
+    private ServerRepository $repository;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app = $this->createMock(Application::class);
+        $this->config = $this->createMock(ConfigRepository::class);
+        $this->resolver = new AppResolver(fn() => $this->app);
+        $this->repository = new ServerRepository($this->resolver);
+    }
+
+    /**
+     * @return void
+     */
+    public function test(): void
+    {
+        $expected = $this->willMakeServer($name = 'v1');
+        $actual = $this->repository->server($name);
+
+        $this->assertInstanceOf(TestServerWithServeSchemaAttribute::class, $actual);
+        $this->assertEquals($expected, $actual);
+        $this->assertTrue($actual->schemas()->existsForModel(TestSchema::$model));
+    }
+
+
+    /**
+     * @param string $name
+     * @param string $class
+     * @return TestServer
+     */
+    private function willMakeServer(string $name, string $class = TestServerWithServeSchemaAttribute::class): TestServerWithServeSchemaAttribute
+    {
+        $this->app
+            ->method('make')
+            ->with(ConfigRepository::class)
+            ->willReturn($this->config);
+
+        $this->config
+            ->expects($this->once())
+            ->method('get')
+            ->with("jsonapi.servers.{$name}")
+            ->willReturn($class);
+
+        return new TestServerWithServeSchemaAttribute($this->resolver, $name);
+    }
+}

--- a/tests/Unit/Server/TestSchema.php
+++ b/tests/Unit/Server/TestSchema.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Core\Tests\Unit\Server;
+
+use LaravelJsonApi\Core\Schema\Schema;
+
+class TestSchema extends Schema
+{
+    public static string $model = 'test';
+
+    /**
+     * Get the resource fields.
+     */
+    public function fields(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Server/TestServerWithServeSchemaAttribute.php
+++ b/tests/Unit/Server/TestServerWithServeSchemaAttribute.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Core\Tests\Unit\Server;
+
+use LaravelJsonApi\Core\Attributes\ServeSchema;
+use LaravelJsonApi\Core\Server\Server as ServerContract;
+
+#[ServeSchema(TestSchema::class)]
+class TestServerWithServeSchemaAttribute extends ServerContract
+{
+    /**
+     * @return void
+     */
+    public function serving(): void
+    {
+        // no-op
+    }
+}


### PR DESCRIPTION
Add support for Attributes for the JSON:API Server.
Now multiple Schemas can be attached to the Server using PHP Attribute:

```php
#[ServeSchema(AcmeSchema::class)]
class AcmeServer extends BaseServer
{
    public function serving(): void
    {
    }
}
```