### PR TITLE
[Fix] Update UUID regex to be case insensitive

### DIFF
--- a/src/Core/Schema/Concerns/MatchesIds.php
+++ b/src/Core/Schema/Concerns/MatchesIds.php
@@ -40,7 +40,7 @@ trait MatchesIds
      */
     public function uuid(): static
     {
-        return $this->matchAs('[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}');
+        return $this->matchAs('[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}');
     }
 
     /**

--- a/tests/Unit/Schema/Concerns/MatchesIdsTest.php
+++ b/tests/Unit/Schema/Concerns/MatchesIdsTest.php
@@ -40,7 +40,7 @@ class MatchesIdsTest extends TestCase
         };
 
         $this->assertSame($id, $id->uuid());
-        $this->assertSame('[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}', $id->pattern());
+        $this->assertSame('[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}', $id->pattern());
         $this->assertTrue($id->match('fca1509e-9178-45fd-8a2b-ae819d34f7e6'));
         $this->assertFalse($id->match('fca1509e917845fd8a2bae819d34f7e6'));
     }

--- a/tests/Unit/Schema/Concerns/MatchesIdsTest.php
+++ b/tests/Unit/Schema/Concerns/MatchesIdsTest.php
@@ -41,6 +41,7 @@ class MatchesIdsTest extends TestCase
 
         $this->assertSame($id, $id->uuid());
         $this->assertSame('[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}', $id->pattern());
+        $this->assertTrue($id->match('FCA1509E-9178-45FD-8A2B-AE819d34f7E6'));
         $this->assertTrue($id->match('fca1509e-9178-45fd-8a2b-ae819d34f7e6'));
         $this->assertFalse($id->match('fca1509e917845fd8a2bae819d34f7e6'));
     }


### PR DESCRIPTION
Adds support for MS SQL Server which uses upper case UUIDs and doesn't accept lower case UUIDs.