### PR TITLE
Tests: add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.2, 8.3, 8.4 ]
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
         laravel: [ 11, 12 ]
 
     steps:


### PR DESCRIPTION
Updates Github Actions to also run tests on PHP 8.5